### PR TITLE
Optionally log demo sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ go.work
 build
 
 *.log
+.vscode

--- a/cmd/lady/comment.go
+++ b/cmd/lady/comment.go
@@ -42,7 +42,9 @@ func commentAction(cc *cli.Context) (err error) {
 	case source == "demo":
 		generator = generate.NewDemo(cc.Int(flagDemoSpeed)) // stream of fake messages is used for input
 		logger = log.NewNull()                              // no output
-		// logger = log.NewFile(logFilePath)                   // log-file is used for output
+		if logFilePath != defaultLogFilePath {              // optionally log-file is used for output
+			logger = log.NewFile(logFilePath)
+		}
 	default:
 		return fmt.Errorf("unknown source: %s", source)
 	}

--- a/cmd/lady/flags.go
+++ b/cmd/lady/flags.go
@@ -19,6 +19,10 @@ const (
 	flagSpeakCheers = "speak-cheers"
 )
 
+const (
+	defaultLogFilePath = "fpvc-lady.log"
+)
+
 func getFlags() []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
@@ -40,7 +44,7 @@ func getFlags() []cli.Flag {
 			Usage:    "Path to the log file: save events to (--source serial) or read events from (--source log).",
 			EnvVars:  []string{"LOG_FILE"},
 			Required: false,
-			Value:    "fpvc-lady.log",
+			Value:    defaultLogFilePath,
 		},
 		&cli.StringFlag{
 			Name:     flagLogFrom,


### PR DESCRIPTION
Log demo session when `--log-file` passed together with `--source demo` and log file path differs from default "fpvc-lady.log" -- this means user actually wants to log the demo session events, also less chance to mix real combat sessions and demo sessions if they are in different log files.