### PR TITLE
Gui export stats

### DIFF
--- a/gui/src/App.js
+++ b/gui/src/App.js
@@ -168,23 +168,23 @@ function App() {
         {showLady
           ? <img src={ladyBW} alt="FPV Combat Lady" style={{marginTop: "70px", maxWidth: "80vw"}} onClick={() => toggleLady()} />
           :  showConfig
-              ? (<Options
-                  config={config}
-                  setConfig={setConfig}
-                  roundTimeMarks={roundTimeMarks}
-                  countDownMarks={countDownMarks}
-                  toggleSettings={toggleSettings}
-                />)
-              : (<Main
-                  config={config}
-                  loading={loading}
-                  countDownMarks={countDownMarks(config.lang)}
-                  roundTimeMarks={roundTimeMarks}
-                  sendMessage={sendMessage}
-                  isAdmin={isAdmin}
-                  ladyUp={ladyUp}
-                  msgs={msgs}
-                />)
+            ? (<Options
+                config={config}
+                setConfig={setConfig}
+                roundTimeMarks={roundTimeMarks}
+                countDownMarks={countDownMarks}
+                toggleSettings={toggleSettings}
+              />)
+            : (<Main
+                config={config}
+                loading={loading}
+                countDownMarks={countDownMarks(config.lang)}
+                roundTimeMarks={roundTimeMarks}
+                sendMessage={sendMessage}
+                isAdmin={isAdmin}
+                ladyUp={ladyUp}
+                msgs={msgs}
+              />)
         }
       </Container>
     </div>

--- a/gui/src/App.js
+++ b/gui/src/App.js
@@ -166,26 +166,25 @@ function App() {
       </header>
       <Container maxWidth="false" className="fpvcm-container">
         {showLady
-          ? <img src={ladyBW} alt="FPV Combat Lady" style={{marginTop: "70px", maxWidth: "80vw", flex: "justify"}} onClick={() => toggleLady()} />
-          : (loading && !showConfig && !showLady)
-            ? (<Loading lang={config.lang} />)
-            : showConfig
-              ? (<Options
-                  config={config}
-                  setConfig={setConfig}
-                  roundTimeMarks={roundTimeMarks}
-                  countDownMarks={countDownMarks}
-                  toggleSettings={toggleSettings}
-                />)
-              : (<Main
-                  config={config}
-                  countDownMarks={countDownMarks(config.lang)}
-                  roundTimeMarks={roundTimeMarks}
-                  sendMessage={sendMessage}
-                  isAdmin={isAdmin}
-                  ladyUp={ladyUp}
-                  msgs={msgs}
-                />)
+          ? <img src={ladyBW} alt="FPV Combat Lady" style={{marginTop: "70px", maxWidth: "80vw"}} onClick={() => toggleLady()} />
+          :  showConfig
+            ? (<Options
+                config={config}
+                setConfig={setConfig}
+                roundTimeMarks={roundTimeMarks}
+                countDownMarks={countDownMarks}
+                toggleSettings={toggleSettings}
+              />)
+            : (<Main
+                config={config}
+                loading={loading}
+                countDownMarks={countDownMarks(config.lang)}
+                roundTimeMarks={roundTimeMarks}
+                sendMessage={sendMessage}
+                isAdmin={isAdmin}
+                ladyUp={ladyUp}
+                msgs={msgs}
+              />)
         }
       </Container>
     </div>

--- a/gui/src/App.js
+++ b/gui/src/App.js
@@ -11,7 +11,6 @@ import txt from './locale/locale'
 
 import Main from './component/Main'
 import Options from './component/Options'
-import Loading from './component/Loading'
 
 import CssBaseline from '@mui/material/CssBaseline'
 import Container from '@mui/material/Container'

--- a/gui/src/App.scss
+++ b/gui/src/App.scss
@@ -48,6 +48,9 @@
   .hide-narrow {
     display: none !important
   }
+  .loading_info {
+    display: none
+  }
 }
 
 @media (min-width:680px) {

--- a/gui/src/component/Loading.js
+++ b/gui/src/component/Loading.js
@@ -4,20 +4,13 @@ import animation from '../img/loading.gif'
 
 import txt from '../locale/locale'
 
-import Box from '@mui/material/Box'
-import Grid from '@mui/material/Unstable_Grid2'
-
 function Loading(props) {
 
   return (
-    <Box className="fpvcm-container_box">
-      <Grid container spacing={4}>
-        <Grid xl={12} lg={12} md={12} sm={12} xs={12} className="fpvcm-loading">
-          <img src={animation} alt="Loading" style={{maxHeight: '45px'}} /><br />
-          {txt('loading', props.lang)}...
-        </Grid>
-      </Grid>
-    </Box>
+    <div style={{display: "flex", alignItems: "center", justifyContent: "center", position: "relative", right: "-20%"}}>
+      <img src={animation} alt="Loading" style={{maxHeight: '35px', marginRight: '10px'}} />
+      <span className="loading_info">{txt('loading', props.lang)}...</span>
+    </div>
   );
 }
 

--- a/gui/src/component/Main.js
+++ b/gui/src/component/Main.js
@@ -4,6 +4,8 @@ import '../App.scss'
 
 import txt from '../locale/locale'
 
+import Loading from '../component/Loading'
+
 import Box from '@mui/material/Box'
 import Grid from '@mui/material/Unstable_Grid2'
 // import Slider from '@mui/material/Slider'
@@ -50,12 +52,33 @@ function Main(props) {
     return 0
   }
 
-  function downloadData(full) {
-    let filename = 'fpvcombat_session_' + new Date().toJSON().slice(0,19).replace('T', '__')
+  function downloadData(full, stats) {
+    let filename = 'fpvcombat_session_'
+    filename += stats ? 'stats_' : ''
+    filename += new Date().toJSON().slice(0,19).replace('T', '__')
     filename += full ? '__all' : ''
     let type = 'text'
     let data = ''
-    if (props.msgs.length > 0) {
+    if (stats) {
+      data += txt('player', props.config.lang).substring(0, 16).padEnd(16, ' ') + ' | '
+      data += txt('desc', props.config.lang).substring(0, 20).padEnd(20, ' ') + ' || '
+      data += txt('hits', props.config.lang).substring(0, 12).padStart(12, ' ') + ' | '
+      data += txt('damage', props.config.lang).substring(0, 12).padStart(12, ' ') + ' | '
+      data += txt('lives', props.config.lang).substring(0, 12).padStart(12, ' ') + ' | '
+      data += txt('score', props.config.lang).substring(0, 12).padStart(12, ' ') + ' \n'
+      data += '---------------- | -------------------- || ------------ | ------------ | ------------ | ------------ \n'
+      rows.forEach((row) => {
+        data += (row.playerName.substring(0, 11) + ' (' + row.playerId + ')').padEnd(16, ' ') + ' | '
+        data += row.playerDesc.substring(0, 20).padEnd(20, ' ') + ' || '
+        data += row.hits.toString().substring(0, 12).padStart(12, ' ') + ' | '
+        data += row.damage.toString().substring(0, 12).padStart(12, ' ') + ' | '
+        data += row.lives.toString().substring(0, 12).padStart(12, ' ') + ' | '
+        data += row.score.toString().substring(0, 12).padStart(12, ' ') + ' \n'
+      })
+      data += '\n'
+      data += txt('totalHits', props.config.lang) + ': ' + rows.reduce((total, row) => total += parseInt(row.hits), 0)
+    }
+    else if (!stats && props.msgs.length > 0) {
       data = full ? props.msgs.join('\n\n') : props.msgs[0]
     }
     var file = new Blob([data], {type: type})
@@ -130,6 +153,7 @@ function Main(props) {
               <Tabs value={tab} onChange={switchTab} sx={{color: 'red'}}>
                 <Tab label="Stats" id="fpvcmTab0"  />
                 <Tab label="Log" id="fpvcmTab1" />
+                {props.loading && <Loading lang={props.config.lang} />}
               </Tabs>
             </Box>
               <div
@@ -187,6 +211,15 @@ function Main(props) {
                     </CardContent>
                   </Card>
                 </Box>
+                <Box sx={{ p: 1 }}>
+                  <Grid container spacing={4} style={{marginLeft: '0px'}}>
+                    <Grid xl={4} lg={4} md={4} sm={4} xs={4} style={{paddingTop: '22px'}}>
+                      <Button variant="contained" size="small" onClick={() => downloadData(false, true)} style={{minWidth: '100%', overflow: 'hidden'}}> 
+                        {txt('exportStats', props.config.lang)}
+                      </Button>
+                    </Grid>
+                  </Grid>
+                </Box>
               </div>
               <div
                 role="tabpanel"
@@ -212,12 +245,12 @@ function Main(props) {
                 <Box sx={{ p: 1 }}>
                   <Grid container spacing={4} style={{marginLeft: '0px'}}>
                     <Grid xl={4} lg={4} md={4} sm={4} xs={4} style={{paddingTop: '22px'}}>
-                      <Button variant="contained" size="small" onClick={() => downloadData(false)} style={{minWidth: '100%', overflow: 'hidden'}}> 
+                      <Button variant="contained" size="small" onClick={() => downloadData(false, false)} style={{minWidth: '100%', overflow: 'hidden'}}> 
                         {txt('exportLast', props.config.lang)}
                       </Button>
-                      </Grid>
-                      <Grid xl={4} lg={4} md={4} sm={4} xs={4} style={{paddingTop: '22px'}}>
-                      <Button variant="contained" size="small" onClick={() => downloadData(true)} style={{minWidth: '100%', overflow: 'hidden'}}> 
+                    </Grid>
+                    <Grid xl={4} lg={4} md={4} sm={4} xs={4} style={{paddingTop: '22px'}}>
+                      <Button variant="contained" size="small" onClick={() => downloadData(true, false)} style={{minWidth: '100%', overflow: 'hidden'}}> 
                         {txt('exportAll', props.config.lang)}
                       </Button>
                     </Grid>

--- a/gui/src/locale/text/de-DE.json
+++ b/gui/src/locale/text/de-DE.json
@@ -37,6 +37,7 @@
   "optionsDamagePoints": "Schadenspunkte",
   "optionsResetPin": "PIN zurücksetzen",
   "optionsExit": "zurück",
+  "exportStats": "Export stats",
   "exportLast": "Export letzte",
   "exportAll": "Alles exportieren"
 }

--- a/gui/src/locale/text/en-EN.json
+++ b/gui/src/locale/text/en-EN.json
@@ -38,6 +38,7 @@
   "optionsDamagePoints": "Points for receiving damage",
   "optionsResetPin": "Reset access PIN",
   "optionsExit": "Exit",
+  "exportStats": "Export stats",
   "exportLast": "Export last",
   "exportAll": "Export all"
 }

--- a/gui/src/locale/text/pl-PL.json
+++ b/gui/src/locale/text/pl-PL.json
@@ -38,6 +38,7 @@
   "optionsDamagePoints": "Punkty za bycie trafionym",
   "optionsResetPin": "Zresetuj PIN dostępu",
   "optionsExit": "Wyjście",
+  "exportStats": "Pobierz tabelę",
   "exportLast": "Pobierz ostatnie",
   "exportAll": "Pobierz wszystko"
 }


### PR DESCRIPTION
As requested: a main table is now exportable to TXT, please test if the output is OK (should be, formatting is preserved and made as similar to lady CDM output as possible, too long data will be trimmed to preserve the CMD format).

Loading spinner is also improved (now it does not take the whole screen - just a small animation on top of the tab pane - so that whenever the lady service is down but there is still some data on the frontend side - it is possible to navigate and download files without interruptions - hope it's OK)