### PR TITLE
Do not pollute terminal with websocket parsing errors

### DIFF
--- a/comment_socket.go
+++ b/comment_socket.go
@@ -21,7 +21,6 @@ func handleSocketMessage(message string) {
 	var msg SocketMessage
 	err := json.Unmarshal([]byte(message), &msg)
 	if err != nil {
-		fmt.Println("Error parsing websocket message:", err)
 		return
 	}
 	switch msg.Type {


### PR DESCRIPTION
Fixes #61 

Messages from frontend that can not be parsed/unmarshaled are just ignored, dropped on backend side.

To see all web socket communication (raw), use `--log-socket=fpvc-lady.socket.log`